### PR TITLE
Add React frontend and API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project is a Django application for managing housing resources.
 
+The repository now includes a lightweight React front-end. You can access it by
+visiting `/react/` while the Django server is running. The React app uses a
+simple JSON API served from the Django backend.
+
 ## Prerequisites
 
 - **Python 3.11** (the project was developed using Python 3.11)
@@ -23,6 +27,9 @@ This project is a Django application for managing housing resources.
    python manage.py migrate
    python manage.py runserver
    ```
+
+The React interface requires no build step and is loaded directly from static
+files.
 
 The application will be available at `http://127.0.0.1:8000/` by default.
 

--- a/housing_app/templates/housing_app/react_index.html
+++ b/housing_app/templates/housing_app/react_index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>HUH Connect Madco - React</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-dark text-light">
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script type="text/babel" src="{% static 'js/react-app.js' %}"></script>
+</body>
+</html>

--- a/housing_app/urls.py
+++ b/housing_app/urls.py
@@ -10,4 +10,9 @@ urlpatterns = [
     path('listing/<int:pk>/update/', views.listing_update, name='listing_update'),
     path('listing/<int:pk>/delete/', views.listing_delete, name='listing_delete'),
     path('register/', views.register, name='register'),
+    # React front-end entry
+    path('react/', views.react_index, name='react_index'),
+    # Simple JSON API
+    path('api/listings/', views.api_listings, name='api_listings'),
+    path('api/listings/<int:pk>/', views.api_listing_detail, name='api_listing_detail'),
 ]

--- a/housing_app/views.py
+++ b/housing_app/views.py
@@ -5,6 +5,9 @@ from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import User
 from django import forms
 from django.db.models import Q
+from django.http import JsonResponse, HttpResponseNotAllowed
+from django.views.decorators.csrf import csrf_exempt
+import json
 
 from .models import Listing
 from .forms import ListingForm
@@ -164,3 +167,70 @@ def listing_delete(request, pk):
         listing.delete()
         return redirect('housing_app:listing_list')
     return render(request, 'housing_app/listing_detail.html', {'listing': listing})
+
+# ---------------------- API Views for React Frontend ----------------------
+
+def listing_to_dict(listing):
+    """Serialize a Listing instance into a Python dict."""
+    return {
+        'id': listing.id,
+        'street': listing.street,
+        'city': listing.city,
+        'state': listing.state,
+        'zip': listing.zip,
+        'landlord_cell': listing.landlord_cell,
+        'landlord_email': listing.landlord_email,
+        'is_available': listing.is_available,
+        'bedrooms': listing.bedrooms,
+        'bathrooms': listing.bathrooms,
+        'property_type': listing.property_type,
+        'pets_allowed': listing.pets_allowed,
+        'ada_accessible': listing.ada_accessible,
+        'income_requirement': listing.income_requirement,
+        'past_eviction_allowed': listing.past_eviction_allowed,
+        'sex_offender_allowed': listing.sex_offender_allowed,
+        'criminal_record_allowed': listing.criminal_record_allowed,
+        'additional_info': listing.additional_info,
+        'misc_notes': listing.misc_notes,
+        'image1': listing.image1.url if listing.image1 else None,
+        'image2': listing.image2.url if listing.image2 else None,
+        'image3': listing.image3.url if listing.image3 else None,
+    }
+
+@csrf_exempt
+def api_listings(request):
+    """GET returns all listings; POST creates a new listing."""
+    if request.method == 'GET':
+        qs = Listing.objects.all()
+        data = [listing_to_dict(l) for l in qs]
+        return JsonResponse(data, safe=False)
+    if request.method == 'POST':
+        payload = json.loads(request.body or '{}')
+        form = ListingForm(payload)
+        if form.is_valid():
+            listing = form.save()
+            return JsonResponse(listing_to_dict(listing), status=201)
+        return JsonResponse({'errors': form.errors}, status=400)
+    return HttpResponseNotAllowed(['GET', 'POST'])
+
+@csrf_exempt
+def api_listing_detail(request, pk):
+    """GET, PUT and DELETE operations for a single listing."""
+    listing = get_object_or_404(Listing, pk=pk)
+    if request.method == 'GET':
+        return JsonResponse(listing_to_dict(listing))
+    if request.method == 'PUT':
+        payload = json.loads(request.body or '{}')
+        form = ListingForm(payload, instance=listing)
+        if form.is_valid():
+            listing = form.save()
+            return JsonResponse(listing_to_dict(listing))
+        return JsonResponse({'errors': form.errors}, status=400)
+    if request.method == 'DELETE':
+        listing.delete()
+        return JsonResponse({'deleted': True})
+    return HttpResponseNotAllowed(['GET', 'PUT', 'DELETE'])
+
+def react_index(request):
+    """Serve the React front-end entry point."""
+    return render(request, 'housing_app/react_index.html')

--- a/static/js/react-app.js
+++ b/static/js/react-app.js
@@ -1,0 +1,157 @@
+const { useState, useEffect } = React;
+
+function ListingForm({ listing, onSuccess }) {
+  const [formData, setFormData] = useState(listing || {});
+
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    setFormData({
+      ...formData,
+      [name]: type === 'checkbox' ? checked : value
+    });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const method = listing ? 'PUT' : 'POST';
+    const url = listing ? `/api/listings/${listing.id}/` : '/api/listings/';
+    fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(formData)
+    })
+      .then(res => res.json())
+      .then(() => onSuccess())
+      .catch(err => console.error(err));
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mb-3">
+      <div className="row g-2">
+        <div className="col-md-6">
+          <input className="form-control" placeholder="Street" name="street" value={formData.street || ''} onChange={handleChange} />
+        </div>
+        <div className="col-md-6">
+          <input className="form-control" placeholder="City" name="city" value={formData.city || ''} onChange={handleChange} />
+        </div>
+      </div>
+      <div className="row g-2 mt-2">
+        <div className="col-md-4">
+          <input className="form-control" placeholder="State" name="state" value={formData.state || ''} onChange={handleChange} />
+        </div>
+        <div className="col-md-4">
+          <input className="form-control" placeholder="Zip" name="zip" value={formData.zip || ''} onChange={handleChange} />
+        </div>
+        <div className="col-md-4">
+          <input className="form-control" placeholder="Bedrooms" name="bedrooms" type="number" value={formData.bedrooms || ''} onChange={handleChange} />
+        </div>
+      </div>
+      <div className="row g-2 mt-2">
+        <div className="col-md-4">
+          <input className="form-control" placeholder="Bathrooms" name="bathrooms" type="number" value={formData.bathrooms || ''} onChange={handleChange} />
+        </div>
+        <div className="col-md-4">
+          <select className="form-select" name="property_type" value={formData.property_type || ''} onChange={handleChange}>
+            <option value="">Type</option>
+            <option value="house">House</option>
+            <option value="apartment">Apartment</option>
+            <option value="condo">Condo</option>
+            <option value="group_home">Group Home</option>
+          </select>
+        </div>
+        <div className="col-md-4 form-check form-switch text-start mt-2">
+          <input className="form-check-input" type="checkbox" name="is_available" checked={formData.is_available || false} onChange={handleChange} />
+          <label className="form-check-label ms-2">Available</label>
+        </div>
+      </div>
+      <button className="btn btn-primary mt-3" type="submit">Save</button>
+    </form>
+  );
+}
+
+function App() {
+  const [listings, setListings] = useState([]);
+  const [view, setView] = useState('list');
+  const [current, setCurrent] = useState(null);
+
+  const loadListings = () => {
+    fetch('/api/listings/')
+      .then(res => res.json())
+      .then(data => setListings(data));
+  };
+
+  useEffect(() => {
+    loadListings();
+  }, []);
+
+  const showDetail = (id) => {
+    fetch(`/api/listings/${id}/`)
+      .then(res => res.json())
+      .then(data => { setCurrent(data); setView('detail'); });
+  };
+
+  const deleteListing = (id) => {
+    fetch(`/api/listings/${id}/`, { method: 'DELETE' })
+      .then(() => loadListings());
+  };
+
+  if (view === 'form') {
+    return (
+      <div className="container mt-4">
+        <button className="btn btn-secondary mb-3" onClick={() => { setView('list'); setCurrent(null); }}>Back</button>
+        <ListingForm listing={current} onSuccess={() => { setView('list'); loadListings(); }} />
+      </div>
+    );
+  }
+
+  if (view === 'detail' && current) {
+    return (
+      <div className="container mt-4">
+        <button className="btn btn-secondary mb-3" onClick={() => setView('list')}>Back</button>
+        <h3>{current.street}</h3>
+        <p>{current.city}, {current.state} {current.zip}</p>
+        <p>Bedrooms: {current.bedrooms}</p>
+        <p>Bathrooms: {current.bathrooms}</p>
+        <button className="btn btn-primary me-2" onClick={() => { setView('form'); }}>Edit</button>
+        <button className="btn btn-danger" onClick={() => { deleteListing(current.id); setView('list'); }}>Delete</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mt-4">
+      <div className="d-flex justify-content-between mb-3">
+        <h2>Listings</h2>
+        <button className="btn btn-success" onClick={() => setView('form')}>Add</button>
+      </div>
+      <table className="table table-dark table-bordered">
+        <thead>
+          <tr>
+            <th>Street</th>
+            <th>City</th>
+            <th>State</th>
+            <th>Zip</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {listings.map(l => (
+            <tr key={l.id}>
+              <td>{l.street}</td>
+              <td>{l.city}</td>
+              <td>{l.state}</td>
+              <td>{l.zip}</td>
+              <td>
+                <button className="btn btn-info btn-sm me-2" onClick={() => showDetail(l.id)}>View</button>
+                <button className="btn btn-warning btn-sm me-2" onClick={() => { setCurrent(l); setView('form'); }}>Edit</button>
+                <button className="btn btn-danger btn-sm" onClick={() => deleteListing(l.id)}>Delete</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
## Summary
- add lightweight React-based frontend available at `/react/`
- create simple JSON API endpoints for listings
- provide `react_index.html` template and `react-app.js`
- update README with React usage notes

## Testing
- `python -m py_compile housing_app/views.py housing_app/urls.py housing_site/urls.py`
- `python manage.py check`
