### PR TITLE
Add light/dark mode toggle

### DIFF
--- a/housing_app/templates/housing_app/base.html
+++ b/housing_app/templates/housing_app/base.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html>
 <head>
@@ -63,6 +64,49 @@
       background-color: #fff;
       color: #000;
     }
+
+    /* Light mode overrides */
+    body.light-mode {
+      background-color: #f8f9fa;
+      color: #000;
+    }
+    body.light-mode .navbar-dark.bg-custom {
+      background-color: #e9ecef;
+    }
+    body.light-mode .navbar-dark .navbar-brand {
+      color: #007bff !important;
+    }
+    body.light-mode .page-card {
+      background: #fff;
+      color: #000;
+    }
+    body.light-mode .form-control,
+    body.light-mode .form-select {
+      background-color: #fff;
+      color: #000;
+      border: 1px solid #ced4da;
+    }
+    body.light-mode .form-control::placeholder {
+      color: #6c757d;
+    }
+    body.light-mode .btn-outline-light {
+      border-color: #000;
+      color: #000;
+    }
+    body.light-mode .btn-outline-light:hover {
+      background-color: #000;
+      color: #fff;
+    }
+    body.light-mode table.table-dark {
+      background-color: #fff;
+      color: #000;
+    }
+    body.light-mode .bg-dark {
+      background-color: #fff !important;
+    }
+    body.light-mode .text-white {
+      color: #000 !important;
+    }
   </style>
 </head>
 <body>
@@ -113,6 +157,9 @@
               </a>
             </li>
           {% endif %}
+          <li class="nav-item me-2">
+            <button id="theme-toggle" class="btn btn-outline-light btn-sm" onclick="toggleTheme()">Light Mode</button>
+          </li>
         </ul>
       </div>
     </div>
@@ -128,5 +175,6 @@
 
   <!-- Bootstrap JS Bundle (with Popper) -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{% static 'js/theme-toggle.js' %}"></script>
 </body>
 </html>

--- a/housing_app/templates/housing_app/react_index.html
+++ b/housing_app/templates/housing_app/react_index.html
@@ -4,8 +4,23 @@
 <head>
   <title>HUH Connect Madco - React</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body.light-mode {
+      background-color: #f8f9fa !important;
+      color: #000 !important;
+    }
+    body.light-mode .btn-outline-light {
+      border-color: #000;
+      color: #000;
+    }
+    body.light-mode .btn-outline-light:hover {
+      background-color: #000;
+      color: #fff;
+    }
+  </style>
 </head>
 <body class="bg-dark text-light">
+  <button id="theme-toggle" class="btn btn-outline-light position-fixed top-0 end-0 m-3" onclick="toggleTheme()">Light Mode</button>
   <div id="root"></div>
 
   <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
@@ -14,5 +29,6 @@
 
   <!-- note: no extra spaces around the tag -->
   <script type="text/babel" src="{% static 'js/react-app.js' %}"></script>
+  <script src="{% static 'js/theme-toggle.js' %}"></script>
 </body>
 </html>

--- a/static/js/theme-toggle.js
+++ b/static/js/theme-toggle.js
@@ -1,0 +1,22 @@
+(function() {
+  function applyTheme(mode) {
+    var btn = document.getElementById('theme-toggle');
+    if (mode === 'light') {
+      document.body.classList.add('light-mode');
+      if (btn) btn.textContent = 'Dark Mode';
+    } else {
+      document.body.classList.remove('light-mode');
+      if (btn) btn.textContent = 'Light Mode';
+    }
+  }
+
+  var stored = localStorage.getItem('theme');
+  applyTheme(stored === 'light' ? 'light' : 'dark');
+
+  window.toggleTheme = function() {
+    var isLight = document.body.classList.contains('light-mode');
+    var newMode = isLight ? 'dark' : 'light';
+    localStorage.setItem('theme', newMode);
+    applyTheme(newMode);
+  };
+})();


### PR DESCRIPTION
## Summary
- add JS helper to remember theme and switch between light and dark
- inject toggle button and styling into main Django layout
- apply the same theme toggle to the React page

## Testing
- `python manage.py test`