### PR TITLE
Add OpenAI dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sqlparse==0.5.3
 whitenoise==6.4.0
 requests
 beautifulsoup4
+openai==1.3.1


### PR DESCRIPTION
## Summary
- include `openai==1.3.1` in requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement openai==1.3.1)*
- `python manage.py check`