### PR TITLE
Add sample API data for scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ API key. The response should be a JSON array of listing objects with fields like
 `lease_term`, `hud_subsidy` and `rent`. Listings that meet the Madison County
 requirements will be created automatically.
 
+For quick testing the repository includes `static/sample_listings.json` which
+contains two example listings. When the Django development server is running
+with `DEBUG=True`, this file is available at
+`http://127.0.0.1:8000/static/sample_listings.json`. Supplying this URL to
+`/scrape/api/` demonstrates the import functionality without relying on an
+external service.
+
 ## Deployment
 
 Before deploying to production, collect static assets with:

--- a/static/sample_listings.json
+++ b/static/sample_listings.json
@@ -1,0 +1,26 @@
+[
+  {
+    "street": "123 Maple Ave",
+    "city": "Decatur",
+    "state": "IL",
+    "zip": "62521",
+    "bedrooms": 2,
+    "bathrooms": 1,
+    "property_type": "apartment",
+    "lease_term": 12,
+    "hud_subsidy": "none",
+    "rent": 1100
+  },
+  {
+    "street": "45 Oak Street",
+    "city": "Decatur",
+    "state": "IL",
+    "zip": "62522",
+    "bedrooms": 3,
+    "bathrooms": 2,
+    "property_type": "house",
+    "lease_term": 12,
+    "hud_subsidy": "none",
+    "rent": 1500
+  }
+]


### PR DESCRIPTION
## Summary
- add sample listings JSON data
- document how to use the sample data with `/scrape/api/`

## Testing
- `python manage.py test`