### PR TITLE
Add button for API import

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ API key. The response should be a JSON array of listing objects with fields like
 `lease_term`, `hud_subsidy` and `rent`. Listings that meet the Madison County
 requirements will be created automatically.
 
+For quick testing the repository includes `static/sample_listings.json` which
+contains two example listings. When the Django development server is running
+with `DEBUG=True`, this file is available at
+`http://127.0.0.1:8000/static/sample_listings.json`. Supplying this URL to
+`/scrape/api/` demonstrates the import functionality without relying on an
+external service.
+
 ## Deployment
 
 Before deploying to production, collect static assets with:

--- a/housing_app/templates/housing_app/listing_list.html
+++ b/housing_app/templates/housing_app/listing_list.html
@@ -148,6 +148,9 @@
   <a class="btn btn-outline-light btn-sm mb-3 ms-2" href="{% url 'housing_app:scrape_listings' %}">
     Scrape Listings
   </a>
+  <a class="btn btn-outline-light btn-sm mb-3 ms-2" href="{% url 'housing_app:scrape_api' %}">
+    Import from API
+  </a>
 {% endif %}
 
 <!-- Table of results (Bootstrap table dark) -->

--- a/static/sample_listings.json
+++ b/static/sample_listings.json
@@ -1,0 +1,26 @@
+[
+  {
+    "street": "123 Maple Ave",
+    "city": "Decatur",
+    "state": "IL",
+    "zip": "62521",
+    "bedrooms": 2,
+    "bathrooms": 1,
+    "property_type": "apartment",
+    "lease_term": 12,
+    "hud_subsidy": "none",
+    "rent": 1100
+  },
+  {
+    "street": "45 Oak Street",
+    "city": "Decatur",
+    "state": "IL",
+    "zip": "62522",
+    "bedrooms": 3,
+    "bathrooms": 2,
+    "property_type": "house",
+    "lease_term": 12,
+    "hud_subsidy": "none",
+    "rent": 1500
+  }
+]


### PR DESCRIPTION
## Summary
- link to the API scraping form from the listings page

## Testing
- `python manage.py test`