### PR TITLE
Add map and gallery

### DIFF
--- a/housing_app/templates/housing_app/listing_detail.html
+++ b/housing_app/templates/housing_app/listing_detail.html
@@ -55,18 +55,58 @@
             <p><strong>Misc Notes:</strong> {{ listing.misc_notes }}</p>
           {% endif %}
 
-          <!-- Images -->
-          {% for img in listing.images.all %}
-            <p><strong>Image {{ forloop.counter }}:</strong></p>
-            <img
-              src="{{ img.image.url }}"
-              alt="Property Image {{ forloop.counter }}"
-              class="img-fluid mb-3"
-              style="max-width:100%;"
-            >
-          {% empty %}
+          <!-- Map integration -->
+          {% if listing.street or listing.city or listing.state %}
+            <div class="mb-4">
+              <iframe
+                width="100%"
+                height="300"
+                style="border:0"
+                loading="lazy"
+                allowfullscreen
+                src="https://www.google.com/maps?q={{ listing.street|urlencode }}+{{ listing.city|urlencode }}+{{ listing.state|urlencode }}+{{ listing.zip|urlencode }}&amp;output=embed"
+              ></iframe>
+            </div>
+          {% endif %}
+
+          <!-- Responsive image gallery -->
+          {% if listing.images.all %}
+            <div id="listingCarousel" class="carousel slide mb-3" data-bs-ride="carousel">
+              <div class="carousel-inner">
+                {% for img in listing.images.all %}
+                  <div class="carousel-item {% if forloop.first %}active{% endif %}">
+                    <img
+                      src="{{ img.image.url }}"
+                      class="d-block w-100"
+                      alt="Property Image {{ forloop.counter }}"
+                    >
+                  </div>
+                {% endfor %}
+              </div>
+              <button class="carousel-control-prev" type="button" data-bs-target="#listingCarousel" data-bs-slide="prev">
+                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Previous</span>
+              </button>
+              <button class="carousel-control-next" type="button" data-bs-target="#listingCarousel" data-bs-slide="next">
+                <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Next</span>
+              </button>
+            </div>
+
+            <div class="d-flex flex-wrap mb-4">
+              {% for img in listing.images.all %}
+                <img
+                  src="{{ img.image.url }}"
+                  class="img-thumbnail m-1"
+                  style="width: 100px; cursor: pointer;"
+                  data-bs-target="#listingCarousel"
+                  data-bs-slide-to="{{ forloop.counter0 }}"
+                >
+              {% endfor %}
+            </div>
+          {% else %}
             <p>No images.</p>
-          {% endfor %}
+          {% endif %}
 
           <a href="{% url 'housing_app:listing_list' %}" class="btn btn-outline-light btn-sm">
             Back to List

--- a/housing_app/templates/housing_app/listing_list.html
+++ b/housing_app/templates/housing_app/listing_list.html
@@ -165,6 +165,7 @@
       <th>Bedrooms</th>
       <th>Bathrooms</th>
       <th>Pets?</th>
+      <th>Image</th>
       <th>Actions</th>
     </tr>
   </thead>
@@ -179,6 +180,13 @@
         <td>{{ listing.bedrooms }}</td>
         <td>{{ listing.bathrooms }}</td>
         <td>{% if listing.pets_allowed %}Yes{% else %}No{% endif %}</td>
+        <td>
+          {% with listing.images.first as img %}
+            {% if img %}
+              <img src="{{ img.image.url }}" class="img-thumbnail" style="max-width: 100px;">
+            {% endif %}
+          {% endwith %}
+        </td>
         <td>
           <a
             href="{% url 'housing_app:listing_detail' listing.pk %}"


### PR DESCRIPTION
## Summary
- embed Google Map on listing details
- add responsive carousel gallery with thumbnails
- show listing thumbnail in listing table

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '^venv/')`
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_6838c7b499dc83259f53ff73c2908576