### PR TITLE
Move inline styles to external stylesheet

### DIFF
--- a/housing_app/templates/housing_app/base.html
+++ b/housing_app/templates/housing_app/base.html
@@ -3,119 +3,12 @@
 <html>
 <head>
   <title>HUH Connect MadCo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Load Bootstrap CSS from CDN -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{% static 'css/styles.css' %}">
 
-  <style>
-    /* Body background: very dark gray */
-    body {
-      background-color: #1a1a1a;
-      color: #fff; /* text color white */
-      margin: 0;
-      padding: 0;
-    }
-
-    /* Navbar: darker background */
-    .navbar-dark.bg-custom {
-      background-color: #2b3940; /* dark gray-blue */
-    }
-
-    /* Brand link color (a bright accent) */
-    .navbar-brand {
-      color: #3dc3ff !important;
-      font-family: 'Montserrat', sans-serif;
-      text-shadow: 0 0 4px rgba(61, 195, 255, 0.7);
-    }
-
-    /* Main content “card” area styling */
-    .page-card {
-      background: #2c2c2c;  /* dark gray */
-      color: #fff;          /* text remains white */
-      border-radius: 8px;
-      padding: 2rem;
-      margin-top: 2rem;
-      margin-bottom: 2rem;
-    }
-
-    /* Darker form controls */
-    .form-control,
-    .form-select {
-      background-color: #444;
-      color: #fff;
-      border: 1px solid #555;
-    }
-    .form-control::placeholder {
-      color: #ccc;
-    }
-
-    /* Primary button styling */
-    .btn-primary {
-      background-color: #007bff;
-      border-color: #007bff;
-    }
-    .btn-primary:hover {
-      background-color: #0056b3;
-    }
-
-    /* Outline-light buttons for top-right that blend with navbar */
-    .btn-outline-light {
-      border-color: #fff;
-      color: #fff;
-    }
-    .btn-outline-light:hover {
-      background-color: #fff;
-      color: #000;
-    }
-
-    /* Light mode overrides */
-    body.light-mode {
-      background-color: #f8f9fa;
-      color: #000;
-    }
-    body.light-mode .navbar-dark.bg-custom {
-      background-color: #e9ecef;
-    }
-    body.light-mode .navbar-dark .navbar-brand {
-      color: #007bff !important;
-    }
-    body.light-mode .page-card {
-      background: #fff;
-      color: #000;
-    }
-    body.light-mode .form-control,
-    body.light-mode .form-select {
-      background-color: #fff;
-      color: #000;
-      border: 1px solid #ced4da;
-    }
-    body.light-mode .form-control::placeholder {
-      color: #6c757d;
-    }
-    body.light-mode .btn-outline-light {
-      border-color: #000;
-      color: #000;
-    }
-    body.light-mode .btn-outline-light:hover {
-      background-color: #000;
-      color: #fff;
-    }
-    body.light-mode table.table-dark {
-      background-color: #fff;
-      color: #000;
-    }
-    body.light-mode .table-dark > :not(caption) > * > * {
-      color: #000;
-      background-color: #fff;
-      border-color: #dee2e6;
-    }
-    body.light-mode .bg-dark {
-      background-color: #fff !important;
-    }
-    body.light-mode .text-white {
-      color: #000 !important;
-    }
-  </style>
 </head>
 <body>
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,0 +1,107 @@
+/* Body background: very dark gray */
+body {
+  background-color: #1a1a1a;
+  color: #fff;
+  margin: 0;
+  padding: 0;
+}
+
+/* Navbar: darker background */
+.navbar-dark.bg-custom {
+  background-color: #2b3940;
+}
+
+/* Brand link color (a bright accent) */
+.navbar-brand {
+  color: #3dc3ff !important;
+  font-family: 'Montserrat', sans-serif;
+  text-shadow: 0 0 4px rgba(61, 195, 255, 0.7);
+}
+
+/* Main content "card" area styling */
+.page-card {
+  background: #2c2c2c;
+  color: #fff;
+  border-radius: 8px;
+  padding: 2rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+/* Darker form controls */
+.form-control,
+.form-select {
+  background-color: #444;
+  color: #fff;
+  border: 1px solid #555;
+}
+.form-control::placeholder {
+  color: #ccc;
+}
+
+/* Primary button styling */
+.btn-primary {
+  background-color: #007bff;
+  border-color: #007bff;
+}
+.btn-primary:hover {
+  background-color: #0056b3;
+}
+
+/* Outline-light buttons for top-right that blend with navbar */
+.btn-outline-light {
+  border-color: #fff;
+  color: #fff;
+}
+.btn-outline-light:hover {
+  background-color: #fff;
+  color: #000;
+}
+
+/* Light mode overrides */
+body.light-mode {
+  background-color: #f8f9fa;
+  color: #000;
+}
+body.light-mode .navbar-dark.bg-custom {
+  background-color: #e9ecef;
+}
+body.light-mode .navbar-dark .navbar-brand {
+  color: #007bff !important;
+}
+body.light-mode .page-card {
+  background: #fff;
+  color: #000;
+}
+body.light-mode .form-control,
+body.light-mode .form-select {
+  background-color: #fff;
+  color: #000;
+  border: 1px solid #ced4da;
+}
+body.light-mode .form-control::placeholder {
+  color: #6c757d;
+}
+body.light-mode .btn-outline-light {
+  border-color: #000;
+  color: #000;
+}
+body.light-mode .btn-outline-light:hover {
+  background-color: #000;
+  color: #fff;
+}
+body.light-mode table.table-dark {
+  background-color: #fff;
+  color: #000;
+}
+body.light-mode .table-dark > :not(caption) > * > * {
+  color: #000;
+  background-color: #fff;
+  border-color: #dee2e6;
+}
+body.light-mode .bg-dark {
+  background-color: #fff !important;
+}
+body.light-mode .text-white {
+  color: #000 !important;
+}


### PR DESCRIPTION
## Summary
- extract CSS from `base.html` into `static/css/styles.css`
- reference the new stylesheet and add a responsive viewport meta tag

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '^venv/')`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_683d09b22a048325848b9c40124da711