### PR TITLE
Fix 2FA setup when userprofile missing

### DIFF
--- a/housing_app/views.py
+++ b/housing_app/views.py
@@ -8,7 +8,7 @@ from django import forms
 from django.db.models import Q
 import pyotp
 
-from .models import Listing, ActivityLog
+from .models import Listing, ActivityLog, UserProfile
 from .forms import (
     ListingForm,
     ListingImageFormSet,
@@ -112,7 +112,7 @@ def two_factor_verify(request):
 
 @login_required
 def enable_two_factor(request):
-    profile = request.user.userprofile
+    profile, _ = UserProfile.objects.get_or_create(user=request.user)
     if not profile.two_factor_secret:
         profile.two_factor_secret = pyotp.random_base32()
         profile.save()


### PR DESCRIPTION
## Summary
- ensure `UserProfile` model is imported
- create a user profile on demand when enabling two‑factor auth

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '^venv/')`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_683fadbc2bb88325aa0247dfd8d30a3b