### PR TITLE
Add quick localhost instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,19 @@ Additional PDFs are available in the `Documentation/` folder:
 - `User Documentation.pdf`
 
 These files contain optional design and user guides.
+
+## Quick Localhost Setup
+
+Copy and paste the commands below to recreate the environment and start the
+development server at `http://127.0.0.1:8000/`:
+
+```bash
+rm -rf venv
+python3.12 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+pip install --upgrade pip setuptools wheel
+pip install -r requirements.txt
+python manage.py migrate
+python manage.py runserver
+```


### PR DESCRIPTION
## Summary
- add a section at the end of the README with a quick localhost setup block

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '^venv/')`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6840f9b12d6c8325bf96bc2e49cb2bd9