### PR TITLE
Add confirmation for deleting listings

### DIFF
--- a/housing_app/templates/housing_app/base.html
+++ b/housing_app/templates/housing_app/base.html
@@ -82,5 +82,6 @@
   <!-- Bootstrap JS Bundle (with Popper) -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="{% static 'js/theme-toggle.js' %}"></script>
+  <script src="{% static 'js/confirm-delete.js' %}"></script>
 </body>
 </html>

--- a/housing_app/templates/housing_app/listing_list.html
+++ b/housing_app/templates/housing_app/listing_list.html
@@ -206,7 +206,7 @@
             <form
               method="POST"
               action="{% url 'housing_app:listing_delete' listing.pk %}"
-              class="d-inline-block"
+              class="d-inline-block delete-form"
             >
               {% csrf_token %}
               <button

--- a/static/js/confirm-delete.js
+++ b/static/js/confirm-delete.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const forms = document.querySelectorAll('.delete-form');
+  forms.forEach(function (form) {
+    form.addEventListener('submit', function (e) {
+      if (!confirm('Are you sure you want to delete this post?')) {
+        e.preventDefault();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add JS to confirm listing deletion
- mark delete form with class `delete-form`
- include new script in base template

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '^venv/')`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6840f9e7c2448325937bea101a83dfd2