### PR TITLE
Add back button on 2FA setup page

### DIFF
--- a/housing_app/templates/housing_app/enable_two_factor.html
+++ b/housing_app/templates/housing_app/enable_two_factor.html
@@ -9,6 +9,9 @@
           <p>Scan this code or enter the secret in your authenticator app.</p>
           <pre class="text-center">{{ secret }}</pre>
           <img src="https://api.qrserver.com/v1/create-qr-code/?size=200x200&data={{ uri }}" alt="QR Code" class="d-block mx-auto"/>
+          <div class="text-center mt-3">
+            <a href="{% url 'housing_app:listing_list' %}" class="btn btn-outline-light btn-sm">Back</a>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- let users return to the listing list after enabling 2FA

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '^venv/')`
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_6840fa132b3883258236dcf333b7f4a8