### PR TITLE
Add code verification step to 2FA setup

### DIFF
--- a/housing_app/templates/housing_app/enable_two_factor.html
+++ b/housing_app/templates/housing_app/enable_two_factor.html
@@ -6,11 +6,29 @@
       <div class="card bg-dark text-white shadow">
         <div class="card-body">
           <h2 class="mb-4">Enable Two-Factor Authentication</h2>
-          <p>Scan this code or enter the secret in your authenticator app.</p>
+          <p>
+            Scan this code or enter the secret in your authenticator app, then
+            enter a code from the app to confirm.
+          </p>
           <pre class="text-center">{{ secret }}</pre>
-          <img src="https://api.qrserver.com/v1/create-qr-code/?size=200x200&data={{ uri }}" alt="QR Code" class="d-block mx-auto"/>
+          <img
+            src="https://api.qrserver.com/v1/create-qr-code/?size=200x200&data={{ uri }}"
+            alt="QR Code"
+            class="d-block mx-auto"
+          />
+          <form method="post" class="mt-3">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <button type="submit" class="btn btn-outline-light btn-sm w-100">
+              Enable
+            </button>
+          </form>
           <div class="text-center mt-3">
-            <a href="{% url 'housing_app:listing_list' %}" class="btn btn-outline-light btn-sm">Back</a>
+            <a
+              href="{% url 'housing_app:listing_list' %}"
+              class="btn btn-outline-light btn-sm"
+              >Back</a
+            >
           </div>
         </div>
       </div>

--- a/housing_app/views.py
+++ b/housing_app/views.py
@@ -113,16 +113,35 @@ def two_factor_verify(request):
 @login_required
 def enable_two_factor(request):
     profile, _ = UserProfile.objects.get_or_create(user=request.user)
-    if not profile.two_factor_secret:
-        profile.two_factor_secret = pyotp.random_base32()
-        profile.save()
-    totp_uri = pyotp.totp.TOTP(profile.two_factor_secret).provisioning_uri(
+
+    if request.method == "POST":
+        secret = request.session.get("temp_2fa_secret")
+        if not secret:
+            return redirect("enable_two_factor")
+        form = TwoFactorCodeForm(request.POST)
+        if form.is_valid():
+            totp = pyotp.TOTP(secret)
+            if totp.verify(form.cleaned_data["code"]):
+                profile.two_factor_secret = secret
+                profile.save()
+                request.session.pop("temp_2fa_secret", None)
+                return redirect("housing_app:listing_list")
+            else:
+                form.add_error("code", "Invalid code")
+    else:
+        secret = request.session.get("temp_2fa_secret")
+        if not secret:
+            secret = pyotp.random_base32()
+            request.session["temp_2fa_secret"] = secret
+        form = TwoFactorCodeForm()
+
+    totp_uri = pyotp.totp.TOTP(secret).provisioning_uri(
         request.user.username, issuer_name="HUH Connect"
     )
     return render(
         request,
         "housing_app/enable_two_factor.html",
-        {"secret": profile.two_factor_secret, "uri": totp_uri},
+        {"secret": secret, "uri": totp_uri, "form": form},
     )
 
 


### PR DESCRIPTION
## Summary
- require an authentication code before enabling two-factor authentication
- update 2FA setup template with form for entering the code

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '^venv/')`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68411a7b263483259c681885deed2bf9