### PR TITLE
Add back button in favorites page

### DIFF
--- a/housing_app/templates/housing_app/favorite_list.html
+++ b/housing_app/templates/housing_app/favorite_list.html
@@ -39,4 +39,7 @@
 {% else %}
   <p>No saved listings.</p>
 {% endif %}
+<div class="text-center mt-3">
+  <a href="{% url 'housing_app:listing_list' %}" class="btn btn-outline-light btn-sm">Back</a>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add navigation button linking back to listings on favorites page

## Testing
- `black .`
- `python -m py_compile $(git ls-files '*.py' | grep -v '^venv/')`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68474f4125e88325b91f2422b7cfa81a