### PR TITLE
Limit width of listing filters

### DIFF
--- a/housing_app/templates/housing_app/listing_list.html
+++ b/housing_app/templates/housing_app/listing_list.html
@@ -39,27 +39,27 @@
 
   <!-- Row 1: bedrooms, bathrooms, property_type -->
   <div class="row gx-2 gy-2 mb-3">
-    <div class="col">
+    <div class="col-auto">
       <label>Bedrooms (min):</label>
       <input
         type="number"
         name="bedrooms"
-        class="form-control form-control-sm"
+        class="form-control form-control-sm filter-field"
         value="{{ request.GET.bedrooms|default_if_none:'' }}"
       >
     </div>
-    <div class="col">
+    <div class="col-auto">
       <label>Bathrooms (min):</label>
       <input
         type="number"
         name="bathrooms"
-        class="form-control form-control-sm"
+        class="form-control form-control-sm filter-field"
         value="{{ request.GET.bathrooms|default_if_none:'' }}"
       >
     </div>
-    <div class="col">
+    <div class="col-auto">
       <label>Property Type:</label>
-      <select name="property_type" class="form-select form-select-sm">
+      <select name="property_type" class="form-select form-select-sm filter-field">
         <option value="">Any</option>
         <option value="house" {% if request.GET.property_type == 'house' %}selected{% endif %}>House</option>
         <option value="apartment" {% if request.GET.property_type == 'apartment' %}selected{% endif %}>Apartment</option>
@@ -71,25 +71,25 @@
 
   <!-- Row 2: pets_allowed, ada_accessible, eviction_allowed -->
   <div class="row gx-2 gy-2 mb-3">
-    <div class="col">
+    <div class="col-auto">
       <label>Pets Allowed:</label>
-      <select name="pets_allowed" class="form-select form-select-sm">
+      <select name="pets_allowed" class="form-select form-select-sm filter-field">
         <option value="">Any</option>
         <option value="True" {% if request.GET.pets_allowed == 'True' %}selected{% endif %}>Yes</option>
         <option value="False" {% if request.GET.pets_allowed == 'False' %}selected{% endif %}>No</option>
       </select>
     </div>
-    <div class="col">
+    <div class="col-auto">
       <label>ADA Accessible:</label>
-      <select name="ada_accessible" class="form-select form-select-sm">
+      <select name="ada_accessible" class="form-select form-select-sm filter-field">
         <option value="">Any</option>
         <option value="True" {% if request.GET.ada_accessible == 'True' %}selected{% endif %}>Yes</option>
         <option value="False" {% if request.GET.ada_accessible == 'False' %}selected{% endif %}>No</option>
       </select>
     </div>
-    <div class="col">
+    <div class="col-auto">
       <label>Eviction Allowed:</label>
-      <select name="past_eviction_allowed" class="form-select form-select-sm">
+      <select name="past_eviction_allowed" class="form-select form-select-sm filter-field">
         <option value="">Any</option>
         <option value="True" {% if request.GET.past_eviction_allowed == 'True' %}selected{% endif %}>Yes</option>
         <option value="False" {% if request.GET.past_eviction_allowed == 'False' %}selected{% endif %}>No</option>
@@ -99,17 +99,17 @@
 
   <!-- Row 3: sex_offender_allowed, criminal_record_allowed -->
   <div class="row gx-2 gy-2 mb-3">
-    <div class="col">
+    <div class="col-auto">
       <label>Sex Offender Allowed:</label>
-      <select name="sex_offender_allowed" class="form-select form-select-sm">
+      <select name="sex_offender_allowed" class="form-select form-select-sm filter-field">
         <option value="">Any</option>
         <option value="True" {% if request.GET.sex_offender_allowed == 'True' %}selected{% endif %}>Yes</option>
         <option value="False" {% if request.GET.sex_offender_allowed == 'False' %}selected{% endif %}>No</option>
       </select>
     </div>
-    <div class="col">
+    <div class="col-auto">
       <label>Criminal Record:</label>
-      <select name="criminal_record_allowed" class="form-select form-select-sm">
+      <select name="criminal_record_allowed" class="form-select form-select-sm filter-field">
         <option value="">Any</option>
         <option value="none" {% if request.GET.criminal_record_allowed == 'none' %}selected{% endif %}>None</option>
         <option value="misdemeanor" {% if request.GET.criminal_record_allowed == 'misdemeanor' %}selected{% endif %}>Misdemeanor</option>
@@ -120,9 +120,9 @@
 
   <!-- Row 4: Income Requirement (choice) -->
   <div class="row gx-2 gy-2 mb-3">
-    <div class="col">
+    <div class="col-auto">
       <label>Income Requirement:</label>
-      <select name="income_requirement" class="form-select form-select-sm">
+      <select name="income_requirement" class="form-select form-select-sm filter-field">
         <option value="">Any</option>
         <option value="under_20" {% if request.GET.income_requirement == 'under_20' %}selected{% endif %}>Under $20,000</option>
         <option value="30_40" {% if request.GET.income_requirement == '30_40' %}selected{% endif %}>$30,000-$40,000</option>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -68,6 +68,11 @@ body {
   color: #ccc;
 }
 
+/* Keep filter inputs from stretching too wide */
+.filter-field {
+  max-width: 15rem;
+}
+
 /* Primary button styling */
 .btn-primary {
   background-color: #007bff;


### PR DESCRIPTION
## Summary
- add `.filter-field` CSS class for small filter inputs
- use `col-auto` with `filter-field` on listing filters so they don't stretch

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '^venv/')`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6849f0a75fe0832596d629b111cb3f0b