### PR TITLE
Enable dashboard/export for all user roles

### DIFF
--- a/housing_app/templates/housing_app/base.html
+++ b/housing_app/templates/housing_app/base.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load group_tags %}
 <!DOCTYPE html>
 <html>
 <head>
@@ -38,11 +39,13 @@
                 2FA Setup
               </a>
             </li>
-            <li class="nav-item me-2">
-              <a class="btn btn-outline-light btn-sm" href="{% url 'housing_app:dashboard' %}">
-                Dashboard
-              </a>
-            </li>
+            {% if user|has_group:"Manager" or user|has_group:"Client Services" or user.is_superuser %}
+              <li class="nav-item me-2">
+                <a class="btn btn-outline-light btn-sm" href="{% url 'housing_app:dashboard' %}">
+                  Dashboard
+                </a>
+              </li>
+            {% endif %}
             <li class="nav-item me-2">
               <a class="btn btn-outline-light btn-sm" href="{% url 'housing_app:favorite_list' %}">
                 Favorites

--- a/housing_app/templates/housing_app/listing_list.html
+++ b/housing_app/templates/housing_app/listing_list.html
@@ -151,6 +151,8 @@
   <a class="btn btn-outline-light btn-sm mb-3 ms-2" href="{% url 'housing_app:scrape_api' %}">
     Import from API
   </a>
+{% endif %}
+{% if user|has_group:"Manager" or user|has_group:"Client Services" or user.is_superuser %}
   <a class="btn btn-outline-light btn-sm mb-3 ms-2" href="{% url 'housing_app:dashboard' %}">
     Dashboard
   </a>


### PR DESCRIPTION
## Summary
- load group tag helpers in base template
- show Dashboard navigation item only for approved user groups
- allow Client Services role to access dashboard and export buttons on listings page

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '^venv/')`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6849f32a08d483259b64d492e8ede205