### PR TITLE
Add back button to dashboard and update guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,6 @@ This project is a Django application for managing housing resources. The reposit
 - When adding images or static files, place them under `static/` with meaningful names.
 - Additional folder-specific guidelines are provided in nested `AGENTS.md` files.
 - Avoid committing changes to `db.sqlite3` unless specifically required for sample data.
+- When adding a new view and template that users reach via a redirect, include
+  a "Back" link or button in that template so users can easily return to the
+  previous page (typically the listing list).

--- a/housing_app/AGENTS.md
+++ b/housing_app/AGENTS.md
@@ -13,6 +13,9 @@ This directory contains the primary Django application code.
 - Stick with function-based views to match current style.
 - When updating models, generate migrations with `python manage.py makemigrations` and commit them.
 - Templates live in `templates/` and use standard Django templating.
+  When creating a new page reached via a redirect, include a Back link or
+  button that returns to the previous view (usually the listing list) so users
+  can easily navigate.
 
 ## Testing
 - Run `python -m py_compile $(git ls-files 'housing_app/**/*.py')` before committing.

--- a/housing_app/templates/housing_app/dashboard.html
+++ b/housing_app/templates/housing_app/dashboard.html
@@ -21,4 +21,7 @@
     {% endfor %}
   </tbody>
 </table>
+<div class="mt-3">
+  <a href="{% url 'housing_app:listing_list' %}" class="btn btn-outline-light btn-sm">Back</a>
+</div>
 {% endblock %}

--- a/housing_app/templates/housing_app/listing_list.html
+++ b/housing_app/templates/housing_app/listing_list.html
@@ -153,9 +153,6 @@
   </a>
 {% endif %}
 {% if user|has_group:"Manager" or user|has_group:"Client Services" or user.is_superuser %}
-  <a class="btn btn-outline-light btn-sm mb-3 ms-2" href="{% url 'housing_app:dashboard' %}">
-    Dashboard
-  </a>
   <a class="btn btn-outline-light btn-sm mb-3 ms-2" href="{% url 'housing_app:export_csv' %}">
     Export CSV
   </a>


### PR DESCRIPTION
## Summary
- show a Back button on the dashboard page
- remove the duplicate Dashboard button from the listings page
- remind contributors in `AGENTS.md` to include Back links for new pages

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '^venv/')`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_684a69173c74832586c1a52a5c7b49b7